### PR TITLE
Enhance libsodium loading on osx

### DIFF
--- a/pylibscrypt/libsodium_load.py
+++ b/pylibscrypt/libsodium_load.py
@@ -49,7 +49,13 @@ def get_libsodium():
         try:
             return ctypes.cdll.LoadLibrary('libsodium.dylib')
         except OSError:
-            pass
+            try:
+                libidx = __file__.find('lib')
+                if libidx > 0:
+                    libpath = __file__[0:libidx+3] + '/libsodium.dylib'
+                    return ctypes.cdll.LoadLibrary(libpath)
+            except OSError:
+                pass
     else:
         try:
             return ctypes.cdll.LoadLibrary('libsodium.so')


### PR DESCRIPTION
Currently, pylibscrypt only tries to load `libsodium.dylib` from default paths. The path to the osx app is not present in these paths. Thus, it does not work on osx when packaging the app with a tool like cx_Freeze or py2exe. The packaged app cannot find `libsodium.dylib` if it's not run locally. We have to hack with `DYLD_LIBRARY_PATH` to make it work, or ask the user to install libsodium with Homebrew.

I suggest to mimic `libnacl` behaviour ( https://github.com/saltstack/libnacl/blob/master/libnacl/__init__.py#L38 ) which works nicely on mac and let us package libsodium with the binary.