### PR TITLE
Start using Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,14 @@ python:
     - "3.4"
     - "pypy"
 
+addons:
+    apt:
+        packages:
+            libscrypt-dev
+
 install:
     - make
+    - pip install scrypt
 
 script:
     - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: python
 
+dist:
+    trusty
+
 python:
     - "2.7"
     - "3.4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: python
 
-dist:
-    trusty
+sudo: required
+
+dist: trusty
 
 python:
     - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: python
+
+python:
+    - "2.7"
+    - "3.4"
+    - "pypy"
+
+install:
+    - make
+
+script:
+    - make test
+


### PR DESCRIPTION
Closes #15 

Currently only tests Python version, libscrypt and pyscrypt. Since libsodium is not conveniently available for the environment it is not included.

Coveralls could be added, but not before libsodium is tested, or coverage stats would miss a good portion of what can be tested in a full environment.